### PR TITLE
Destroy players onDestroy

### DIFF
--- a/android/src/main/java/guichaguri/trackplayer/TrackModule.java
+++ b/android/src/main/java/guichaguri/trackplayer/TrackModule.java
@@ -56,6 +56,7 @@ public class TrackModule extends ReactContextBaseJavaModule implements ServiceCo
         super.onCatalystInstanceDestroy();
 
         // Unbinds the service
+        manager.destroy(-1);
         getReactApplicationContext().unbindService(this);
     }
 


### PR DESCRIPTION
There was an issue that even when the application was closed by the user; the service would remain and continue playing.. This will fix that issue.