### PR TITLE
[iOS] Use pause instead of next

### DIFF
--- a/ios/RNTrackPlayer/Logic/MediaWrapper.swift
+++ b/ios/RNTrackPlayer/Logic/MediaWrapper.swift
@@ -128,7 +128,7 @@ class MediaWrapper: AudioPlayerDelegate {
             return true
         }
         
-        stop()
+        pause()
         return false
     }
     
@@ -139,7 +139,7 @@ class MediaWrapper: AudioPlayerDelegate {
             return true
         }
         
-        stop()
+        pause()
         return false
     }
     


### PR DESCRIPTION
This will ensure you can poll for current position when playlist is
exhausted.