### PR TITLE
Fix disable of controls

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -265,6 +265,7 @@ class RNTrackPlayer: RCTEventEmitter, MediaWrapperDelegate {
     // MARK: - Private Helpers
     
     private func toggleRemoteHandler(command: MPRemoteCommand, selector: Selector, enabled: Bool) {
+        if( !enabled ) { return }
         command.removeTarget(self, action: selector)
         command.addTarget(self, action: selector)
         command.isEnabled = enabled


### PR DESCRIPTION
As other plugins might enable the controls, we should not touch
them if not enabled.